### PR TITLE
Replace deprecated param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <artifactId>testcontainers-annotations</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
     <name>testcontainers-annotations</name>
     <description>testcontainers-annotations</description>

--- a/src/main/java/dev/vality/testcontainers/annotations/kafka/KafkaTestcontainerExtension.java
+++ b/src/main/java/dev/vality/testcontainers/annotations/kafka/KafkaTestcontainerExtension.java
@@ -172,7 +172,7 @@ public class KafkaTestcontainerExtension implements BeforeAllCallback, AfterAllC
     }
 
     private String execInContainerKafkaTopicsListCommand(KafkaContainer container) {
-        var kafkaTopicsListCommand = "/usr/bin/kafka-topics --zookeeper localhost:2181 --list";
+        var kafkaTopicsListCommand = "/usr/bin/kafka-topics --bootstrap-server localhost:9092 --list";
         try {
             var stdout = container.execInContainer("/bin/sh", "-c", kafkaTopicsListCommand)
                     .getStdout();


### PR DESCRIPTION
Для проверки корректного создания топиков в текущей версии используется команда:

`/usr/bin/kafka-topics --zookeeper localhost:2181 --list` 

Параметр `--zookeeper` помечен как deprecated в версии kafka 2.8.0 (confluent/cp-kafka:6.2.0) и удалён в версии kafka 3.0.0 (см. [тут](https://kafka.apache.org/documentation/)):

The **--zookeeper** option was removed from the **kafka-topics** and **kafka-reassign-partitions** command line tools. Please use **--bootstrap-server** instead.

Данные изменения позволят использовать confluent/cp-kafka актуальной версии (и не поломают старые).